### PR TITLE
fix: update Pages artifact action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -46,7 +46,7 @@ jobs:
           fi
       - name: Upload artifact
         if: ${{ hashFiles('frontend/package.json') != '' }}
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: frontend/build
 


### PR DESCRIPTION
## Summary
- fix deprecated action usage by switching to `actions/upload-pages-artifact@v3`

## Testing
- `CI=true npm test --prefix frontend -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b962ba4b5483208b295c00c14e4ab5