### PR TITLE
chore: push gh-pages on build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,16 +4,17 @@ on:
   push:
     branches:
       - main
-      - work
+      - gh-pages
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
 jobs:
   build:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,21 +45,27 @@ jobs:
           else
             echo "No package.json found, skipping build"
           fi
-      - name: Upload artifact
+      - name: Push to gh-pages branch
         if: ${{ hashFiles('frontend/package.json') != '' }}
-        uses: actions/upload-pages-artifact@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: frontend/build
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: frontend/build
+          publish_branch: gh-pages
 
   deploy:
-    needs: build
+    if: github.ref == 'refs/heads/gh-pages'
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - uses: actions/checkout@v4
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
       - name: Deploy to GitHub Pages
-        if: ${{ hashFiles('frontend/package.json') != '' }}
+        if: github.ref == 'refs/heads/gh-pages'
         id: deployment
         uses: actions/deploy-pages@v4
 


### PR DESCRIPTION
## Summary
- build pushes frontend output to gh-pages via `peaceiris/actions-gh-pages`
- deploy job only runs on gh-pages with explicit ref check
- grant write permissions for gh-pages updates

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9cb893678832084ee60877b955ede