### PR TITLE
Add homepage and router basename for GitHub Pages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://tsarev2709.github.io/anix_flow",
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-accordion": "^1.2.8",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -60,7 +60,7 @@ const AppContent = () => {
 function App() {
   return (
     <div className="App">
-      <BrowserRouter>
+      <BrowserRouter basename="/anix_flow">
         <AuthProvider>
           <AppContent />
           <Toaster />


### PR DESCRIPTION
## Summary
- specify GitHub Pages `homepage` in `frontend/package.json`
- set `<BrowserRouter>` basename to `/anix_flow` for proper routing

## Testing
- `CI=true yarn test` *(fails: craco not found)*
- `yarn build` *(fails: craco not found)*
- `yarn install` *(fails: tunneling socket could not be established, statusCode=403)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ce702f948320bed95c3af18e4337