### PR TITLE
feat: add video preview for interpolated frames

### DIFF
--- a/frontend/src/components/VersionHistoryModal.js
+++ b/frontend/src/components/VersionHistoryModal.js
@@ -40,16 +40,24 @@ const VersionHistoryModal = ({ isOpen, onClose, history, onRevert, title = "Vers
               <Card key={version.id || index} className="bg-white/5 border-white/10 hover:border-white/20 transition-colors">
                 <CardContent className="p-4">
                   <div className="flex items-start space-x-4">
-                    {/* Image Preview */}
+                    {/* Preview */}
                     <div className="flex-shrink-0">
-                      <img
-                        src={version.image}
-                        alt={`Version ${index + 1}`}
-                        className="w-24 h-16 object-cover rounded border border-white/20"
-                        onError={(e) => {
-                          e.target.src = "https://picsum.photos/200/120?grayscale";
-                        }}
-                      />
+                      {version.image ? (
+                        <img
+                          src={version.image}
+                          alt={`Version ${index + 1}`}
+                          className="w-24 h-16 object-cover rounded border border-white/20"
+                          onError={(e) => {
+                            e.target.src = "https://picsum.photos/200/120?grayscale";
+                          }}
+                        />
+                      ) : version.video ? (
+                        <video
+                          src={version.video}
+                          className="w-24 h-16 object-cover rounded border border-white/20"
+                          controls
+                        />
+                      ) : null}
                     </div>
 
                     {/* Version Details */}


### PR DESCRIPTION
## Summary
- enable selecting interpolated frames with video previews
- allow prompt-based edits and uploads for video frames
- support video previews in frame history modal

## Testing
- `cd frontend && yarn test --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68c3360506a88320951d221cc20da73c