### PR TITLE
Fix background music toggle

### DIFF
--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -31,14 +31,17 @@ const Layout = ({ children, activeTab, setActiveTab }) => {
     audioRef.current.volume = musicVolume[0] / 100;
   }, [musicVolume]);
 
-  useEffect(() => {
+  const handleMusicToggle = (enabled) => {
+    setMusicEnabled(enabled);
     if (!audioRef.current) return;
-    if (musicEnabled) {
-      audioRef.current.play();
+    if (enabled) {
+      audioRef.current.play().catch((err) => {
+        console.warn('Failed to play background music:', err);
+      });
     } else {
       audioRef.current.pause();
     }
-  }, [musicEnabled]);
+  };
 
   const tabs = [
     { id: 'dashboard', label: 'Мои проекты', icon: Home },
@@ -117,7 +120,7 @@ const Layout = ({ children, activeTab, setActiveTab }) => {
               <div className="space-y-4">
                 <div className="flex items-center justify-between">
                   <Label htmlFor="bg-music" className="text-sm">Фоновая музыка</Label>
-                  <Switch id="bg-music" checked={musicEnabled} onCheckedChange={setMusicEnabled} />
+                  <Switch id="bg-music" checked={musicEnabled} onCheckedChange={handleMusicToggle} />
                 </div>
                 <div className="space-y-2">
                   <Label className="text-sm">Громкость</Label>


### PR DESCRIPTION
## Summary
- play background music immediately when user toggles setting and handle playback errors

## Testing
- `cd frontend && yarn test --watchAll=false` *(fails: No tests found, exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c3dd77a6448320a3d8bbe8380972cf